### PR TITLE
fix: remove deprecated husky v9 shebang and sourcing lines

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
 npm run docs:index
 npm run docs:toc
 npm run docs:format


### PR DESCRIPTION
The legacy `#!/usr/bin/env sh` and `. husky.sh` lines cause failures on Windows (WSL relay error) and are deprecated in husky v9+.